### PR TITLE
Support sharing DB connection with Sequel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "bridgetown", ENV["BRIDGETOWN_VERSION"] if ENV["BRIDGETOWN_VERSION"]
 group :test do
   gem "minitest"
   gem "minitest-reporters"
+  gem "pg", "~> 1.3"
+  gem "sequel-activerecord_connection", "~> 1.2"
   gem "shoulda"
 end
-
-gem "pg", "~> 1.3", group: :test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Bridgetown Active Record plugin
 
-This plugin adds Active Record support to Bridgetown sites (v1.2 or higher). You can pull data from a database (currently PostgreSQL is officially supported) during a static build or during server requests (or both!) and use many of the features you know and love from Active Record in Rails—including migrations!
+This plugin adds [Active Record](https://guides.rubyonrails.org/active_record_basics.html) support to Bridgetown sites (v1.2 or higher). You can pull data from a database (currently PostgreSQL is officially supported) during a static build or during server requests (or both!) and use many of the features you know and love from Active Record in Rails—including migrations!
+
+In addition, if you also like using the [Sequel gem](https://github.com/jeremyevans/sequel) for your database access, this plugin can support instantiating Sequel with a shared DB connection via the [sequel-activerecord_connection](https://github.com/janko/sequel-activerecord_connection) extension ([see below](#using-with-sequel)).
 
 ## Installation
 
@@ -108,6 +110,28 @@ BridgetownActiveRecord.load_tasks(models_dir: "app/models")
 ```
 
 (Don't forget to update your autoload path in `config/initializers.rb` accordingly.)
+
+## Using with Sequel
+
+To set up [Sequel](https://github.com/jeremyevans/sequel) using the same database connection as Active Record, follow these steps:
+
+First, install the sequel-activerecord_connection gem:
+
+```sh
+bundle add sequel-activerecord_connection
+```
+
+Next, update your configuration in `config/initializers.rb` as follows:
+
+```ruby
+init :"bridgetown-activerecord", sequel_support: :postgres # or mysql2 or sqlite3
+```
+
+Now you should be able to call `DB` to access the Sequel API anywhere in your Bridgetown or Roda code:
+
+```ruby
+DB.tables # => [:ar_internal_metadata, :schema_migrations, etc.]
+```
 
 ## Testing
 

--- a/lib/bridgetown-activerecord/initializer.rb
+++ b/lib/bridgetown-activerecord/initializer.rb
@@ -20,9 +20,14 @@ module BridgetownActiveRecord
   end
 end
 
-Bridgetown.initializer :"bridgetown-activerecord" do |config|
+Bridgetown.initializer :"bridgetown-activerecord" do |config, sequel_support: nil|
   ActiveRecord::Base.establish_connection(
     BridgetownActiveRecord.db_configuration(config)[Bridgetown.environment]
   )
   ActiveRecord::Base.logger = BridgetownActiveRecord.log_writer
+
+  next unless sequel_support
+
+  require "sequel"
+  DB = Sequel.send(sequel_support, extensions: :activerecord_connection)
 end

--- a/test/fixtures/config/initializers.rb
+++ b/test/fixtures/config/initializers.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Bridgetown.configure do
-  init :"bridgetown-activerecord"
+  init :"bridgetown-activerecord", sequel_support: :postgres
 end

--- a/test/test_bridgetown_activerecord.rb
+++ b/test/test_bridgetown_activerecord.rb
@@ -28,6 +28,7 @@ class TestBridgetownActiverecord < Bridgetown::TestCase
 
     should "connect to the database" do
       assert_includes @contents, "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter"
+      assert_equal "#<Sequel::Postgres::Database: {:adapter=>:postgres, :extensions=>:activerecord_connection}>", DB.inspect
     end
   end
 end


### PR DESCRIPTION
In lieu of a standalone "bridgetown-sequel" plugin (which I'm sure will arrive eventually), I think this is a pretty rad solution. Have your Active Record cake and eat Sequel too! (or something like that 🤓)

Testing feedback most appreciated! (Read the updated [Readme](https://github.com/bridgetownrb/bridgetown-activerecord/tree/support-sequel) and make sure your site's `Gemfile` has `github: "bridgetownrb/bridgetown-activerecord", branch: "support-sequel"` on the line following `gem "bridgetown-activerecord"`)